### PR TITLE
B33G5-181 and B33G5-189 Profile Settings Functionality

### DIFF
--- a/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
+++ b/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
@@ -26,7 +26,7 @@ public class ProfileSettingsPage {
     @FindBy(id="expand")
     public WebElement buttonExpandMenu;
 
-    @FindBy(xpath = "//a[text()=\"Settings\"]")
+    @FindBy(xpath = "//li[@data-id=\"settings\"]//a")
     public WebElement linkSettings;
 
     @FindBy(id="email")

--- a/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
+++ b/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
@@ -6,6 +6,7 @@ import org.junit.Assert;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.Select;
 
 public class ProfileSettingsPage {
 
@@ -29,22 +30,39 @@ public class ProfileSettingsPage {
     public WebElement inputEmailField;
 
     @FindBy(id = "languageinput")
-    public WebElement dropdownLanguage;
+    private WebElement languageDropdownElement;
 
     public void goToProfileSettingPage() {
         buttonExpandMenu.click();
-        BrowserUtils.sleep(2);
-
+        BrowserUtils.sleep(1);
         if (linkSettings.isDisplayed()) {
             linkSettings.click();
-            BrowserUtils.sleep(2);
         } else {
-            // TODO trow error that linkSettings not displayed
+            throw new AssertionError("Settings link is not displayed"); // Throw an error if not visible
         }
         String expectedUrl = "https://qa.symund.com/index.php/settings/user";
         Assert.assertEquals(Driver.getDriver().getCurrentUrl(), expectedUrl);
     }
 
+    // Method to get the currently selected language value
+    public String getSelectedLanguageValue() {
+        Select select = new Select(languageDropdownElement); // Create Select object
+        WebElement selectedOption = select.getFirstSelectedOption();
+        return selectedOption.getAttribute("value");
+    }
+
+    // Method to get the currently selected language text (e.g., "Español (España)")
+    public String getSelectedLanguageText() {
+        Select select = new Select(languageDropdownElement); // Create Select object
+        WebElement selectedOption = select.getFirstSelectedOption();
+        return selectedOption.getText();
+    }
+
+    // Method to select a language by its value attribute
+    public void selectLanguageByValue(String language) {
+        Select select = new Select(languageDropdownElement); // Create Select object
+        select.selectByValue(language);
+    }
 }
 
 

--- a/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
+++ b/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
@@ -1,0 +1,52 @@
+package com.group5_sprint2_cloud.pages;
+
+import com.group5_sprint2_cloud.utilities.Driver;
+import org.junit.Assert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
+
+import java.util.List;
+
+public class ProfileSettingsPage {
+
+    public ProfileSettingsPage() {
+        PageFactory.initElements(Driver.getDriver(), this);
+    }
+
+    @FindBy(id="displayname")
+    public WebElement userFullName;
+
+    @FindBy(xpath = "//div[@id='settings']//span[@title]/@title")
+    public WebElement userName;
+
+    @FindBy(id="expand")
+    public WebElement buttonExpandMenu;
+
+    @FindBy(xpath = "//a[text()=\"Settings\"]")
+    public WebElement linkSettings;
+
+    @FindBy(id="email")
+    public WebElement inputEmailField;
+
+    @FindBy(id="languageinput")
+    public WebElement dropdownLanguage;
+
+    public void goToProfileSettingPage() {
+        buttonExpandMenu.click();
+        if (linkSettings.isDisplayed()) {
+            linkSettings.click();
+        } else {
+            // TODO trow error that linkSettings not displayed
+        }
+        String expectedUrl = "https://qa.symund.com/index.php/settings/user";
+        Assert.assertEquals(Driver.getDriver().getCurrentUrl(),expectedUrl);
+    }
+
+}
+
+
+

--- a/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
+++ b/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
@@ -62,6 +62,7 @@ public class ProfileSettingsPage {
     public void selectLanguageByValue(String language) {
         Select select = new Select(languageDropdownElement); // Create Select object
         select.selectByValue(language);
+        BrowserUtils.sleep(1);
     }
 }
 

--- a/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
+++ b/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
@@ -1,15 +1,11 @@
 package com.group5_sprint2_cloud.pages;
+
 import com.group5_sprint2_cloud.utilities.BrowserUtils;
 import com.group5_sprint2_cloud.utilities.Driver;
 import org.junit.Assert;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.Select;
-
-import java.util.List;
 
 public class ProfileSettingsPage {
 
@@ -17,22 +13,22 @@ public class ProfileSettingsPage {
         PageFactory.initElements(Driver.getDriver(), this);
     }
 
-    @FindBy(id="displayname")
+    @FindBy(id = "displayname")
     public WebElement userFullName;
 
-    @FindBy(xpath = "//div[@id='settings']//span[@title]/@title")
+    @FindBy(xpath = "//div[@id='settings']//span[@title]")
     public WebElement userName;
 
-    @FindBy(id="expand")
+    @FindBy(id = "expand")
     public WebElement buttonExpandMenu;
 
     @FindBy(xpath = "//li[@data-id=\"settings\"]//a")
     public WebElement linkSettings;
 
-    @FindBy(id="email")
+    @FindBy(id = "email")
     public WebElement inputEmailField;
 
-    @FindBy(id="languageinput")
+    @FindBy(id = "languageinput")
     public WebElement dropdownLanguage;
 
     public void goToProfileSettingPage() {
@@ -46,7 +42,7 @@ public class ProfileSettingsPage {
             // TODO trow error that linkSettings not displayed
         }
         String expectedUrl = "https://qa.symund.com/index.php/settings/user";
-        Assert.assertEquals(Driver.getDriver().getCurrentUrl(),expectedUrl);
+        Assert.assertEquals(Driver.getDriver().getCurrentUrl(), expectedUrl);
     }
 
 }

--- a/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
+++ b/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
@@ -1,5 +1,5 @@
 package com.group5_sprint2_cloud.pages;
-
+import com.group5_sprint2_cloud.utilities.BrowserUtils;
 import com.group5_sprint2_cloud.utilities.Driver;
 import org.junit.Assert;
 import org.openqa.selenium.By;
@@ -37,8 +37,11 @@ public class ProfileSettingsPage {
 
     public void goToProfileSettingPage() {
         buttonExpandMenu.click();
+        BrowserUtils.sleep(2);
+
         if (linkSettings.isDisplayed()) {
             linkSettings.click();
+            BrowserUtils.sleep(2);
         } else {
             // TODO trow error that linkSettings not displayed
         }

--- a/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
+++ b/src/test/java/com/group5_sprint2_cloud/pages/ProfileSettingsPage.java
@@ -26,11 +26,23 @@ public class ProfileSettingsPage {
     @FindBy(xpath = "//li[@data-id=\"settings\"]//a")
     public WebElement linkSettings;
 
+    @FindBy(id = "phone")
+    public WebElement inputPhoneField;
+
     @FindBy(id = "email")
     public WebElement inputEmailField;
 
     @FindBy(id = "languageinput")
     private WebElement languageDropdownElement;
+
+    @FindBy(xpath = "//label[@for='displayname']")
+    private WebElement fullNameLabel;
+
+    @FindBy(xpath = "//label[@for='email']")
+    private WebElement emailLabel;
+
+    @FindBy(xpath = "//label[@for='phone']")
+    private WebElement phoneNumberLabel;
 
     public void goToProfileSettingPage() {
         buttonExpandMenu.click();
@@ -64,6 +76,19 @@ public class ProfileSettingsPage {
         select.selectByValue(language);
         BrowserUtils.sleep(1);
     }
+
+    public String getFullNameLabelText() {
+        return fullNameLabel.getText();
+    }
+
+    public String getEmailLabelText() {
+        return emailLabel.getText();
+    }
+
+    public String getPhoneNumberLabelText() {
+        return phoneNumberLabel.getText();
+    }
+
 }
 
 

--- a/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
+++ b/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
@@ -1,6 +1,7 @@
 package com.group5_sprint2_cloud.step_definitions;
 
 import com.group5_sprint2_cloud.pages.ProfileSettingsPage;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.junit.Assert;
@@ -8,8 +9,9 @@ import org.junit.Assert;
 public class ProfileStepDefs {
 
     ProfileSettingsPage profileSettingsPage = new ProfileSettingsPage();
+    String userProperEmail = "admin@example.com";
 
-    @When("user click to the Avatar")
+    @When("user click to the menu button")
     public void user_click_to_the_avatar() {
         // Write code here that turns the phrase above into concrete actions
         profileSettingsPage.buttonExpandMenu.click();
@@ -37,37 +39,26 @@ public class ProfileStepDefs {
     @When("the user enters a proper email address to email input box")
     public void the_user_enters_a_proper_email_address_to_email_input_box() {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        profileSettingsPage.inputEmailField.clear();
+        profileSettingsPage.inputEmailField.sendKeys(userProperEmail);
     }
 
     @Then("the email field should display user's proper address")
     public void the_email_field_should_display_user_s_proper_address() {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        Assert.assertEquals(profileSettingsPage.inputEmailField.getAttribute("value"), userProperEmail);
     }
 
-    @When("the user's preferred language is {string}")
-    public void the_user_s_preferred_language_is(String string) {
-        // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
-    }
-
-    @When("the user selects a language {string}")
+    @And("the user selects a language {string}")
     public void the_user_selects_a_language(String string) {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        profileSettingsPage.selectLanguageByValue(string);
+        Assert.assertEquals(profileSettingsPage.getSelectedLanguageValue(), string);
     }
 
     @Then("the language field should display {string}")
     public void the_language_field_should_display(String string) {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        Assert.assertEquals(profileSettingsPage.getSelectedLanguageText(), string);
     }
-
-    @Then("website's language changed to {string}")
-    public void website_s_language_changed_to(String string) {
-        // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
-    }
-
 }

--- a/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
+++ b/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
@@ -1,0 +1,60 @@
+package com.group5_sprint2_cloud.step_definitions;
+
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+public class ProfileStepDefs {
+
+    @When("user click to the Avatar")
+    public void user_click_to_the_avatar() {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @When("user click to the Settings")
+    public void user_click_to_the_settings() {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @Then("user should see the same name and username")
+    public void user_should_see_the_same_name_and_username() {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @When("the user is on the Settings page")
+    public void the_user_is_on_the_settings_page() {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @When("the user enters a proper email address to email input box")
+    public void the_user_enters_a_proper_email_address_to_email_input_box() {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @Then("the email field should display user's proper address")
+    public void the_email_field_should_display_user_s_proper_address() {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+
+    @When("the user's preferred language is {string}")
+    public void the_user_s_preferred_language_is(String string) {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @When("the user selects a language {string}")
+    public void the_user_selects_a_language(String string) {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @Then("the language field should display {string}")
+    public void the_language_field_should_display(String string) {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+    @Then("website's language changed to {string}")
+    public void website_s_language_changed_to(String string) {
+        // Write code here that turns the phrase above into concrete actions
+        throw new io.cucumber.java.PendingException();
+    }
+
+}

--- a/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
+++ b/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
@@ -2,6 +2,7 @@ package com.group5_sprint2_cloud.step_definitions;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import com.group5_sprint2_cloud.pages.ProfileSettingsPage;
 
 public class ProfileStepDefs {
 
@@ -23,7 +24,8 @@ public class ProfileStepDefs {
     @When("the user is on the Settings page")
     public void the_user_is_on_the_settings_page() {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        new ProfileSettingsPage().goToProfileSettingPage();
+
     }
     @When("the user enters a proper email address to email input box")
     public void the_user_enters_a_proper_email_address_to_email_input_box() {

--- a/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
+++ b/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
@@ -1,6 +1,7 @@
 package com.group5_sprint2_cloud.step_definitions;
 
 import com.group5_sprint2_cloud.pages.ProfileSettingsPage;
+import com.group5_sprint2_cloud.utilities.BrowserUtils;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -13,52 +14,65 @@ public class ProfileStepDefs {
 
     @When("user click to the menu button")
     public void user_click_to_the_avatar() {
-        // Write code here that turns the phrase above into concrete actions
         profileSettingsPage.buttonExpandMenu.click();
     }
 
     @When("user click to the Settings")
     public void user_click_to_the_settings() {
-        // Write code here that turns the phrase above into concrete actions
         profileSettingsPage.linkSettings.click();
     }
 
     @Then("user should see the same name and username")
     public void user_should_see_the_same_name_and_username() {
-        // Write code here that turns the phrase above into concrete actions
         Assert.assertEquals(profileSettingsPage.userFullName.getAttribute("value"), profileSettingsPage.userName.getAttribute("title"));
     }
 
     @When("the user is on the Settings page")
     public void the_user_is_on_the_settings_page() {
-        // Write code here that turns the phrase above into concrete actions
         profileSettingsPage.goToProfileSettingPage();
 
     }
 
     @When("the user enters a proper email address to email input box")
     public void the_user_enters_a_proper_email_address_to_email_input_box() {
-        // Write code here that turns the phrase above into concrete actions
         profileSettingsPage.inputEmailField.clear();
         profileSettingsPage.inputEmailField.sendKeys(userProperEmail);
     }
 
     @Then("the email field should display user's proper address")
     public void the_email_field_should_display_user_s_proper_address() {
-        // Write code here that turns the phrase above into concrete actions
         Assert.assertEquals(profileSettingsPage.inputEmailField.getAttribute("value"), userProperEmail);
     }
 
     @And("the user selects a language {string}")
     public void the_user_selects_a_language(String string) {
-        // Write code here that turns the phrase above into concrete actions
         profileSettingsPage.selectLanguageByValue(string);
         Assert.assertEquals(profileSettingsPage.getSelectedLanguageValue(), string);
     }
 
     @Then("the language field should display {string}")
     public void the_language_field_should_display(String string) {
-        // Write code here that turns the phrase above into concrete actions
         Assert.assertEquals(profileSettingsPage.getSelectedLanguageText(), string);
+    }
+
+    @Then("the user should see titles: {string}, {string}, {string}")
+    public void the_user_should_see_titles(String string, String string2, String string3) {
+        // "Full name", "Email", "Phone Number"
+        Assert.assertEquals(string, profileSettingsPage.getFullNameLabelText());
+        Assert.assertEquals(string2, profileSettingsPage.getEmailLabelText());
+        Assert.assertEquals(string3, profileSettingsPage.getPhoneNumberLabelText());
+    }
+
+    @When("the user enters {string} into the Phone Number input field")
+    public void i_enter_into_the_input_field(String string) {
+        // the user enters "abc123" into the "Phone Number" input field
+        profileSettingsPage.inputPhoneField.clear();
+        profileSettingsPage.inputPhoneField.sendKeys(string);
+        BrowserUtils.sleep(1);
+    }
+
+    @Then("the input should be rejected")
+    public void the_input_should_be_rejected() {
+        Assert.assertNotNull(profileSettingsPage.inputPhoneField.getAttribute("value"));
     }
 }

--- a/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
+++ b/src/test/java/com/group5_sprint2_cloud/step_definitions/ProfileStepDefs.java
@@ -1,37 +1,45 @@
 package com.group5_sprint2_cloud.step_definitions;
 
+import com.group5_sprint2_cloud.pages.ProfileSettingsPage;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import com.group5_sprint2_cloud.pages.ProfileSettingsPage;
+import org.junit.Assert;
 
 public class ProfileStepDefs {
+
+    ProfileSettingsPage profileSettingsPage = new ProfileSettingsPage();
 
     @When("user click to the Avatar")
     public void user_click_to_the_avatar() {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        profileSettingsPage.buttonExpandMenu.click();
     }
+
     @When("user click to the Settings")
     public void user_click_to_the_settings() {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        profileSettingsPage.linkSettings.click();
     }
+
     @Then("user should see the same name and username")
     public void user_should_see_the_same_name_and_username() {
         // Write code here that turns the phrase above into concrete actions
-        throw new io.cucumber.java.PendingException();
+        Assert.assertEquals(profileSettingsPage.userFullName.getAttribute("value"), profileSettingsPage.userName.getAttribute("title"));
     }
+
     @When("the user is on the Settings page")
     public void the_user_is_on_the_settings_page() {
         // Write code here that turns the phrase above into concrete actions
-        new ProfileSettingsPage().goToProfileSettingPage();
+        profileSettingsPage.goToProfileSettingPage();
 
     }
+
     @When("the user enters a proper email address to email input box")
     public void the_user_enters_a_proper_email_address_to_email_input_box() {
         // Write code here that turns the phrase above into concrete actions
         throw new io.cucumber.java.PendingException();
     }
+
     @Then("the email field should display user's proper address")
     public void the_email_field_should_display_user_s_proper_address() {
         // Write code here that turns the phrase above into concrete actions
@@ -43,16 +51,19 @@ public class ProfileStepDefs {
         // Write code here that turns the phrase above into concrete actions
         throw new io.cucumber.java.PendingException();
     }
+
     @When("the user selects a language {string}")
     public void the_user_selects_a_language(String string) {
         // Write code here that turns the phrase above into concrete actions
         throw new io.cucumber.java.PendingException();
     }
+
     @Then("the language field should display {string}")
     public void the_language_field_should_display(String string) {
         // Write code here that turns the phrase above into concrete actions
         throw new io.cucumber.java.PendingException();
     }
+
     @Then("website's language changed to {string}")
     public void website_s_language_changed_to(String string) {
         // Write code here that turns the phrase above into concrete actions

--- a/src/test/resources/features/US013_ProfileSettings.feature
+++ b/src/test/resources/features/US013_ProfileSettings.feature
@@ -2,11 +2,11 @@
 Feature: Edit/Enter Profile Settings Functionality
 
   @B33G5-186
-  Scenario Outline: Verify that User can see at least following titles inside “Personal Info” under Profile Settings page; => Full name/Email/Phone Number
+  Scenario Outline: Verify that User can see at least following titles inside “Personal Info” under Profile Settings page; => Full name/Email/Phone number
     Given the user logged in as "<userType>"
     When the user is on the Settings page
     And the user selects a language "en"
-    Then the user should see titles: "Full name", "Email", "Phone Number"
+    Then the user should see titles: "Full name", "Email", "Phone number"
     Examples:
       | userType |
       | user     |
@@ -28,7 +28,7 @@ Feature: Edit/Enter Profile Settings Functionality
   Scenario Outline: Verify that User cannot pass any characters except numbers into the "Phone Number" input box.
     Given the user logged in as "<userType>"
     When the user is on the Settings page
-    And the user enters "abc123" into the "Phone Number" input field
+    And the user enters "abc123" into the Phone Number input field
     Then the input should be rejected
     Examples:
       | userType |

--- a/src/test/resources/features/US013_ProfileSettings.feature
+++ b/src/test/resources/features/US013_ProfileSettings.feature
@@ -1,0 +1,36 @@
+@B33G5-189
+Feature: Edit/Enter Profile Settings Functionality
+
+  @B33G5-186
+  Scenario Outline: Verify that User can see at least following titles inside “Personal Info” under Profile Settings page; => Full name/Email/Phone Number
+    Given the user logged in as "<userType>"
+    When the user is on the Settings page
+    And the user selects a language "en"
+    Then the user should see titles: "Full name", "Email", "Phone Number"
+    Examples:
+      | userType |
+      | user     |
+      | employee |
+
+  @B33G5-187
+  Scenario Outline: Verify that Name of the user in the Settings field should be the same with Full Name input box
+    Given the user logged in as "<userType>"
+    When the user is on the Settings page
+    When user click to the menu button
+    And  user click to the Settings
+    Then user should see the same name and username
+    Examples:
+      | userType |
+      | user     |
+      | employee |
+
+  @B33G5-188
+  Scenario Outline: Verify that User cannot pass any characters except numbers into the "Phone Number" input box.
+    Given the user logged in as "<userType>"
+    When the user is on the Settings page
+    And the user enters "abc123" into the "Phone Number" input field
+    Then the input should be rejected
+    Examples:
+      | userType |
+      | user     |
+      | employee |

--- a/src/test/resources/features/US014_ProfileSettings.feature
+++ b/src/test/resources/features/US014_ProfileSettings.feature
@@ -5,14 +5,13 @@ Feature: Check/Change Profile Settings Functionality
   Scenario Outline: Full name and username should be the same
     Given the user logged in as "<userType>"
     When the user is on the Settings page
-    When user click to the Avatar
+    When user click to the menu button
     And  user click to the Settings
     Then user should see the same name and username
     Examples:
       | userType |
       | user     |
       | employee |
-
 
   @B33G5-177
   Scenario Outline: User can enter a proper e-mail to Email input box.
@@ -29,10 +28,10 @@ Feature: Check/Change Profile Settings Functionality
   Scenario Outline: Verify user can change Language.
     Given the user logged in as "<userType>"
     When the user is on the Settings page
-    And the user's preferred language is "English (US)"
-    When the user selects a language "Español (España)"
+    And the user selects a language "en"
+    Then the language field should display "English (US)"
+    When the user selects a language "es"
     Then the language field should display "Español (España)"
-    And website's language changed to "Español (España)"
     Examples:
       | userType |
       | user     |

--- a/src/test/resources/features/US014_ProfileSettings.feature
+++ b/src/test/resources/features/US014_ProfileSettings.feature
@@ -15,7 +15,7 @@ Feature: Check/Change Profile Settings Functionality
 
   @B33G5-177
   Scenario Outline: User can enter a proper e-mail to Email input box.
-    Given the user is logged in as "<userType>"
+    Given the user logged in as "<userType>"
     When the user is on the Settings page
     And the user enters a proper email address to email input box
     Then the email field should display user's proper address
@@ -26,12 +26,12 @@ Feature: Check/Change Profile Settings Functionality
 
   @B33G5-178
   Scenario Outline: Verify user can change Language.
-    Given the user is logged in as "<userType>"
+    Given the user logged in as "<userType>"
     When the user is on the Settings page
     And the user's preferred language is "English (US)"
     When the user selects a language "Español (España)"
     Then the language field should display "Español (España)"
-    And website's language changed to Spanish
+    And website's language changed to "Español (España)"
     Examples:
       | userType |
       | user     |

--- a/src/test/resources/features/US014_ProfileSettings.feature
+++ b/src/test/resources/features/US014_ProfileSettings.feature
@@ -1,0 +1,38 @@
+@B33G5-181
+Feature: Check/Change Profile Settings Functionality
+
+  @B33G5-173
+  Scenario Outline: Full name and username should be the same
+    Given the user logged in as "<userType>"
+    When user click to the Avatar
+    And  user click to the Settings
+    Then user should see the same name and username
+    Examples:
+      | userType |
+      | user     |
+      | employee |
+
+
+  @B33G5-177
+  Scenario Outline: User can enter a proper e-mail to Email input box.
+    Given the user is logged in as "<userType>"
+    When the user is on the Settings page
+    And the user enters a proper email address to email input box
+    Then the email field should display user's proper address
+    Examples:
+      | userType |
+      | user     |
+      | employee |
+
+  @B33G5-178
+  Scenario Outline: Verify user can change Language.
+    Given the user is logged in as "<userType>"
+    When the user is on the Settings page
+    And the user's preferred language is "English (US)"
+    When the user selects a language "Español (España)"
+    Then the language field should display "Español (España)"
+    And website's language changed to Spanish
+    Examples:
+      | userType |
+      | user     |
+      | employee |

--- a/src/test/resources/features/US014_ProfileSettings.feature
+++ b/src/test/resources/features/US014_ProfileSettings.feature
@@ -2,7 +2,7 @@
 Feature: Check/Change Profile Settings Functionality
 
   @B33G5-173
-  Scenario Outline: Full name and username should be the same
+  Scenario Outline: Verify user can see his name and username
     Given the user logged in as "<userType>"
     When the user is on the Settings page
     When user click to the menu button
@@ -14,7 +14,7 @@ Feature: Check/Change Profile Settings Functionality
       | employee |
 
   @B33G5-177
-  Scenario Outline: User can enter a proper e-mail to Email input box.
+  Scenario Outline: Verify user can enter a proper e-mail to Email input box
     Given the user logged in as "<userType>"
     When the user is on the Settings page
     And the user enters a proper email address to email input box
@@ -25,7 +25,7 @@ Feature: Check/Change Profile Settings Functionality
       | employee |
 
   @B33G5-178
-  Scenario Outline: Verify user can change Language.
+  Scenario Outline: Verify user can change Language
     Given the user logged in as "<userType>"
     When the user is on the Settings page
     And the user selects a language "en"

--- a/src/test/resources/features/US014_ProfileSettings.feature
+++ b/src/test/resources/features/US014_ProfileSettings.feature
@@ -4,6 +4,7 @@ Feature: Check/Change Profile Settings Functionality
   @B33G5-173
   Scenario Outline: Full name and username should be the same
     Given the user logged in as "<userType>"
+    When the user is on the Settings page
     When user click to the Avatar
     And  user click to the Settings
     Then user should see the same name and username


### PR DESCRIPTION
### US-013 Edit/Enter Profile Settings Functionality
**User Story :**
As a user, I should be able to change profile info settings under the Profile module.
**Acceptance Criteria:**
1. User can see at least following titles inside “Personal Info” under Profile Settings page; => Full name/Email/Phone Number
2. Name of the user in the Settings field should be the same with Full Name input box
3. User cannot pass any characters except numbers into the "Phone Number" input box.

### US-014 Check/Change Profile Settings Functionality
**User Story :**
As a user, I should be able to check or change profile info settings under the Profile module
**Acceptance Criteria:**
1. Full name and username should be the same.
2. User can enter a proper e-mail to Email input box.
3. User can change Language.
